### PR TITLE
Add repository governance and CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,47 @@
+name: Bug report
+description: Report reproducible behavior that is not working as expected
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for helping improve dsh-kanban. Please do not report security vulnerabilities here; follow SECURITY.md instead.
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the problem and what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open ...
+        2. Click ...
+        3. See ...
+    validations:
+      required: true
+  - type: input
+    id: dsh-version
+    attributes:
+      label: DeepSeek Harness version
+      placeholder: e.g. 0.1.0
+  - type: input
+    id: plugin-version
+    attributes:
+      label: dsh-kanban version
+      placeholder: e.g. 1.0.0
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Operating system, browser, and any other relevant details.
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Remove secrets and personal data before sharing logs.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/alpacachen/dsh-kanban/security/advisories/new
+    about: Report security vulnerabilities privately

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: Feature request
+description: Suggest an improvement or a new capability
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: Describe the use case or limitation rather than only the proposed solution.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Explain how you would like dsh-kanban to behave.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Share any workarounds or alternative designs you considered.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add mockups, screenshots, or related links if useful.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      production-dependencies:
+        dependency-type: production
+      development-dependencies:
+        dependency-type: development
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- What changed, and why? -->
+
+## Validation
+
+<!-- List the checks you ran. -->
+
+- [ ] `pnpm typecheck`
+- [ ] `pnpm build`
+- [ ] The generated `lib/client.js` is up to date, when applicable
+
+## Screenshots
+
+<!-- Add screenshots for visible UI changes, or write "Not applicable". -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.8.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Build
+        run: pnpm build
+
+      - name: Verify generated client bundle
+        run: git diff --exit-code -- lib/client.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 .pnpm-store/
+.npm-cache/
 dist/
 *.tgz
 .DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to dsh-kanban
+
+Thanks for taking the time to contribute. Bug reports, feature ideas, documentation improvements, and pull requests are welcome.
+
+## Before you start
+
+- Search existing issues and pull requests to avoid duplicates.
+- Open an issue before starting a large or behavior-changing contribution so the approach can be discussed first.
+- Keep each pull request focused on one change.
+
+## Local development
+
+You need Node.js 22 or later and pnpm.
+
+```sh
+pnpm install
+pnpm typecheck
+pnpm build
+```
+
+The browser client source lives in `src/client/`. Its generated bundle, `lib/client.js`, is committed and published with the package. If you change client code, run `pnpm build` and include the updated bundle in your pull request.
+
+For an unminified debugging build:
+
+```sh
+node build.mjs --no-minify
+```
+
+## Pull requests
+
+Before opening a pull request:
+
+1. Run `pnpm typecheck`.
+2. Run `pnpm build`.
+3. Confirm `git diff --exit-code -- lib/client.js` produces no output after the build.
+4. Explain what changed, why it changed, and how you verified it.
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 alpacachen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do not open a public issue for a suspected security vulnerability.
+
+Use GitHub's private vulnerability reporting for this repository when available. If that option is unavailable, contact the repository owner privately through their GitHub profile.
+
+Include the affected version, reproduction steps, potential impact, and any suggested mitigation. You should receive an initial response within seven days. Please allow reasonable time for a fix before making details public.
+
+## Supported versions
+
+Security fixes are applied to the latest release. Users should upgrade to the most recent published version before reporting an issue that may already have been fixed.


### PR DESCRIPTION
## Summary

- add CI for frozen dependency installation, typechecking, building, and generated bundle verification
- add Dependabot configuration for npm and GitHub Actions
- add the MIT license, contribution guide, and security policy
- add bug and feature issue forms plus a pull request template
- ignore the local npm cache directory

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm build`
- `git diff --exit-code -- lib/client.js`
- `git diff --check`