### PR TITLE
Release 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alpacachen/dsh-kanban",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A kanban board plugin for DeepSeek Harness: a 'Board' tab in conversations plus 13 kanban_* AI tools, per-workspace isolation and disk persistence. Built with React, TypeScript, dnd-kit, shadcn/ui and Tailwind CSS.",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
## Summary
- bump `@alpacachen/dsh-kanban` from 1.0.1 to 1.0.2
- trigger the automated npm and GitHub Release workflow after merge

## Validation
- confirmed npm version 1.0.2 is unused
- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm build`
- generated `lib/client.js` remains clean
- `npm pack --dry-run` produced the expected 1.0.2 package with 8 files