### PR TITLE
Release 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alpacachen/dsh-kanban",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "A kanban board plugin for DeepSeek Harness: a 'Board' tab in conversations plus 13 kanban_* AI tools, per-workspace isolation and disk persistence. Built with React, TypeScript, dnd-kit, shadcn/ui and Tailwind CSS.",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
## Summary
- bump `@alpacachen/dsh-kanban` from `1.0.3` to `1.1.0`
- trigger the release workflow for the manual board refresh feature merged in #14

Merging this PR will publish npm package `@alpacachen/dsh-kanban@1.1.0`, create tag `v1.1.0`, and create the matching GitHub Release.

## Validation
- `pnpm typecheck`
- `pnpm build`
- `pnpm check:client-bundle`
- confirmed npm latest is `1.0.3` and `1.1.0` is available