### PR TITLE
test: add automated quality gates for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,14 +38,14 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      - name: Unit and integration tests
+        run: pnpm test
+
       - name: Build
         run: pnpm build
 
-      - name: Schema migration self-check
-        run: pnpm check:schema
-
-      - name: Load pipeline self-check
-        run: pnpm check:pipeline
-
       - name: Check client bundle registration
         run: pnpm check:client-bundle
+
+      - name: Check npm package contents
+        run: pnpm check:package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,10 @@ jobs:
         if: steps.version.outputs.changed == 'true'
         run: pnpm typecheck
 
+      - name: Unit and integration tests
+        if: steps.version.outputs.changed == 'true'
+        run: pnpm test
+
       - name: Build
         if: steps.version.outputs.changed == 'true'
         run: pnpm build
@@ -89,6 +93,10 @@ jobs:
       - name: Check client bundle registration
         if: steps.version.outputs.changed == 'true'
         run: pnpm check:client-bundle
+
+      - name: Check npm package contents
+        if: steps.version.outputs.changed == 'true'
+        run: pnpm check:package
 
       - name: Pack release artifact
         if: steps.version.outputs.changed == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ dist/
 lib/client.js
 *.tgz
 .DS_Store
-kanban-board-*.json
+.dsh-kanban.json
+.dsh-kanban.json.*

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
  *
  * 职责：
  *  - 按工作区（项目）隔离：boards 以 workspaceId 为键，每个工作区一块独立看板
- *  - 磁盘持久化：经 ctx.fs 写入 <workspaceRoot>/kanban-board-<workspaceId>.json
+ *  - 磁盘持久化：经 ctx.fs 写入 <workspace.path>/.dsh-kanban.json
  *  - 模型工具：经 ctx.tools.register 注册 14 个 kanban_* 工具
  *  - 浏览器数据层：经 ctx.get('webServer') 注册 /api/kanban 前缀路由
  *
@@ -275,41 +275,53 @@ export function apply(ctx) {
   ]
 
   // ---- 持久化定位 ----
-  const root = () => {
-    const p = getPolicy()
-    return p && typeof p.workspaceRoot === 'string' ? p.workspaceRoot : undefined
+  const BOARD_FILE = '.dsh-kanban.json'
+  const workspaceKey = (workspace) => String(workspace.id || workspace.path)
+  const writePolicyFor = (workspace, session) => {
+    const policy = getPolicy()
+    const resolved =
+      policy && typeof policy.resolve === 'function'
+        ? policy.resolve(session ? { session } : {})
+        : { mode: (policy && policy.defaultMode) || 'workspace-write' }
+    return { ...resolved, workspaceRoot: workspace.path }
   }
-  const fileName = (wsid) => 'kanban-board-' + wsid + '.json'
-  const resolveFile = async (wsid) => {
+  const resolveFile = async (workspace) => {
     const fs = getFs()
     if (!fs) return null
     try {
-      return await fs.resolve(fileName(wsid), root() ? { cwd: root() } : {})
+      return await fs.resolve(BOARD_FILE, { cwd: workspace.path })
     } catch (err) {
-      console.log('dsh-kanban: 解析看板文件失败，退回内存模式：' + ((err && err.message) || err))
+      console.log(
+        'dsh-kanban: 解析工作区看板文件失败 ' + workspaceKey(workspace) + '：' + ((err && err.message) || err),
+      )
       return null
     }
   }
-  const targetOf = async (wsid) => {
-    if (!fileTargets.has(wsid)) fileTargets.set(wsid, await resolveFile(wsid))
-    return fileTargets.get(wsid)
+  const targetOf = async (workspace) => {
+    const key = workspaceKey(workspace)
+    if (!fileTargets.has(key)) fileTargets.set(key, await resolveFile(workspace))
+    return fileTargets.get(key)
   }
-  const persistedFlag = (wsid) => fileTargets.has(wsid) && fileTargets.get(wsid) !== null
+  const persistedFlag = (workspace) => {
+    const key = workspaceKey(workspace)
+    return fileTargets.has(key) && fileTargets.get(key) !== null
+  }
 
   // ---- 看板读写 ----
 
-  // 备份原文件为 <文件名>.<suffix>（复制而非移动，保证原文件在写回前始终存在）
-  const backupFile = async (wsid, suffix) => {
+  // 备份原文件为 .dsh-kanban.json.<suffix>（复制而非移动，保证原文件在写回前始终存在）
+  const backupFile = async (workspace, suffix, session) => {
     const fs = getFs()
-    const target = await targetOf(wsid)
+    const target = await targetOf(workspace)
     if (!fs || !target) return null
+    const key = workspaceKey(workspace)
     try {
       const text = await fs.readText(target)
-      const backupTarget = await fs.resolve(fileName(wsid) + '.' + suffix, root() ? { cwd: root() } : {})
-      await fs.writeText(backupTarget, text)
+      const backupTarget = await fs.resolve(BOARD_FILE + '.' + suffix, { cwd: workspace.path })
+      await fs.writeText(backupTarget, text, undefined, undefined, writePolicyFor(workspace, session))
       return backupTarget
     } catch (err) {
-      console.log('dsh-kanban: 备份失败 ' + wsid + ' (' + suffix + ')：' + ((err && err.message) || err))
+      console.log('dsh-kanban: 备份失败 ' + key + ' (' + suffix + ')：' + ((err && err.message) || err))
       return null
     }
   }
@@ -326,14 +338,15 @@ export function apply(ctx) {
   }
   const timestamp = () => new Date().toISOString().replace(/[:.]/g, '-')
 
-  // 首次访问某工作区时从磁盘加载；异常数据一律不阻塞看板可用性
-  const boardOf = async (wsid) => {
-    let board = boards.get(wsid)
+  // 首次访问某工作区时从该工作区根目录加载；异常数据一律不阻塞看板可用性
+  const boardOf = async (workspace, session) => {
+    const key = workspaceKey(workspace)
+    let board = boards.get(key)
     if (board) return board
     board = { schemaVersion: SCHEMA_VERSION, columns: [], labels: [], cards: [], activities: [], warnings: [] }
-    boards.set(wsid, board)
+    boards.set(key, board)
     const fs = getFs()
-    const target = await targetOf(wsid)
+    const target = await targetOf(workspace)
     let migrated = false
     if (fs && target) {
       try {
@@ -346,19 +359,19 @@ export function apply(ctx) {
           board.cards = parsed.data.cards
           board.activities = Array.isArray(parsed.data.activities) ? parsed.data.activities : []
           migrated = parsed.migrated
-          // 迁移场景：写回前先把迁移前的原文件备份下来，保证可回滚
+          // schema 迁移场景：写回前先把迁移前的原文件备份下来，保证可回滚
           if (parsed.migrated) {
-            await backupFile(wsid, 'bak-v' + parsed.fromVersion)
+            await backupFile(workspace, 'bak-v' + parsed.fromVersion, session)
           }
         } else {
           // 损坏 / 结构无效 / 版本超前：原文件已无法安全读取，先备份再以空板继续
           const suffix =
             parsed.kind === 'unsupported' ? 'unsupported-v' + parsed.version : 'corrupt-' + timestamp()
-          await backupFile(wsid, suffix)
+          await backupFile(workspace, suffix, session)
         }
       } catch (err) {
         // 尚无看板文件（首次使用）或 fs 读取异常，保留默认空板
-        console.log('dsh-kanban: 读取看板失败 ' + wsid + '：' + ((err && err.message) || err))
+        console.log('dsh-kanban: 读取看板失败 ' + key + '：' + ((err && err.message) || err))
       }
     }
     for (const col of board.columns) bumpSeq(col.id)
@@ -370,14 +383,15 @@ export function apply(ctx) {
     if (board.labels.length === 0) {
       board.labels = DEFAULT_LABELS.map((l) => ({ ...l }))
     }
-    // 升级写回：迁移成功即落盘新版本，保证每个文件只迁移一次
-    if (migrated && fs && target) await save(wsid)
+    // schema 升级写回：迁移成功即落盘新版本，保证每个文件只迁移一次
+    if (migrated && fs && target) await save(workspace, session)
     return board
   }
-  const save = async (wsid) => {
+  const save = async (workspace, session) => {
     const fs = getFs()
-    const target = await targetOf(wsid)
-    const board = boards.get(wsid)
+    const target = await targetOf(workspace)
+    const key = workspaceKey(workspace)
+    const board = boards.get(key)
     if (!fs || !target || !board) return
     try {
       await fs.writeText(
@@ -389,9 +403,12 @@ export function apply(ctx) {
           cards: board.cards,
           activities: Array.isArray(board.activities) ? board.activities : [],
         }),
+        undefined,
+        undefined,
+        writePolicyFor(workspace, session),
       )
     } catch (err) {
-      console.log('dsh-kanban: 保存失败 ' + wsid + '：' + ((err && err.message) || err))
+      console.log('dsh-kanban: 保存失败 ' + key + '：' + ((err && err.message) || err))
     }
   }
 
@@ -449,11 +466,11 @@ export function apply(ctx) {
   }
 
   // ---- 核心数据操作：工具与浏览器 HTTP 共用同一份逻辑 ----
-  const dispatch = async (wsid, method, args, source) => {
-    const board = await boardOf(wsid)
+  const dispatch = async (workspace, method, args, source, session) => {
+    const board = await boardOf(workspace, session)
     const a = args || {}
     const actor = source === 'agent' ? 'agent' : 'human'
-    const persisted = () => persistedFlag(wsid)
+    const persisted = () => persistedFlag(workspace)
     const result = (extra) => ({ board: cloneBoard(board), persisted: persisted(), warnings: takeWarnings(board), ...extra })
 
     switch (method) {
@@ -491,7 +508,7 @@ export function apply(ctx) {
             priority: card.priority ?? null,
           },
         })
-        await save(wsid)
+        await save(workspace, session)
         return result({ message: 'Card added to "' + col.title + '"' })
       }
 
@@ -526,7 +543,7 @@ export function apply(ctx) {
           if (after.priority !== before.priority) {
             record(board, { cardId: card.id, type: 'card_priority_changed', source: actor, field: 'priority', from: before.priority, to: after.priority })
           }
-          await save(wsid)
+          await save(workspace, session)
         }
         return card
           ? result({ message: 'Card updated' })
@@ -540,7 +557,7 @@ export function apply(ctx) {
         if (card) {
           record(board, { cardId: id, type: 'card_deleted', source: actor, meta: { title: card.title } })
         }
-        await save(wsid)
+        await save(workspace, session)
         return result({ message: 'Card deleted' })
       }
 
@@ -562,7 +579,7 @@ export function apply(ctx) {
         if (fromTitle !== target.title) {
           record(board, { cardId: card.id, type: 'card_moved', source: actor, field: 'columnId', from: fromTitle, to: target.title, meta: { title: card.title } })
         }
-        await save(wsid)
+        await save(workspace, session)
         return result({ message: 'Moved to "' + target.title + '"' })
       }
 
@@ -570,7 +587,7 @@ export function apply(ctx) {
         const title = str(a.title, '').slice(0, 40) || 'New list'
         board.columns.push({ id: nextId('c'), title })
         record(board, { cardId: null, type: 'column_added', source: actor, meta: { column: title } })
-        await save(wsid)
+        await save(workspace, session)
         return result({ message: 'List added: "' + title + '"' })
       }
 
@@ -582,7 +599,7 @@ export function apply(ctx) {
           if (col.title !== before) {
             record(board, { cardId: null, type: 'column_renamed', source: actor, field: 'title', from: before, to: col.title, meta: { column: col.title } })
           }
-          await save(wsid)
+          await save(workspace, session)
         }
         return col ? result({ message: 'List renamed' }) : result({ error: 'List not found' })
       }
@@ -602,7 +619,7 @@ export function apply(ctx) {
           }
         }
         record(board, { cardId: null, type: 'column_deleted', source: actor, meta: { column: deleted.title } })
-        await save(wsid)
+        await save(workspace, session)
         return result({ message: 'List deleted, cards moved to "' + board.columns[0].title + '"' })
       }
 
@@ -615,7 +632,7 @@ export function apply(ctx) {
           ? Math.max(0, Math.min(Math.floor(a.toIndex), board.columns.length))
           : board.columns.length
         board.columns.splice(toIndex, 0, col)
-        await save(wsid)
+        await save(workspace, session)
         return result({ message: 'List order updated' })
       }
 
@@ -625,7 +642,7 @@ export function apply(ctx) {
         if (findLabel(board, name)) return result({ error: 'Label already exists' })
         board.labels.push({ name, color: normColor(a.color) || '#94a3b8' })
         record(board, { cardId: null, type: 'label_added', source: actor, meta: { label: name } })
-        await save(wsid)
+        await save(workspace, session)
         return result({ message: 'Label added: "' + name + '"' })
       }
 
@@ -652,7 +669,7 @@ export function apply(ctx) {
             record(board, { cardId: null, type: 'label_color_changed', source: actor, field: 'color', from: beforeColor, to: label.color, meta: { label: label.name } })
           }
         }
-        await save(wsid)
+        await save(workspace, session)
         return result({ message: 'Label updated' })
       }
 
@@ -668,7 +685,7 @@ export function apply(ctx) {
           }
         }
         record(board, { cardId: null, type: 'label_deleted', source: actor, meta: { label: name } })
-        await save(wsid)
+        await save(workspace, session)
         return result({ message: 'Label deleted' })
       }
 
@@ -677,27 +694,42 @@ export function apply(ctx) {
     }
   }
 
-  // ---- 工具执行上下文 -> 工作区 id ----
-  const wsidOfExec = async (exec) => {
+  // ---- 工具执行上下文 / 浏览器 workspaceId -> 工作区 ----
+  const workspaceOfExec = async (exec) => {
     const agent = exec && exec.agent
-    const cwd = agent && agent.session && agent.session.header && agent.session.header.cwd
-    if (typeof cwd === 'string' && cwd) {
-      const registry = getWorkspaceRegistry()
-      if (registry) {
-        try {
-          const ws = await registry.resolveByPath(cwd)
-          if (ws) return ws.id
-        } catch (err) {
-          console.log('dsh-kanban: 解析工作区失败：' + ((err && err.message) || err))
-        }
+    const session = agent && agent.session
+    const cwd = session && session.header && session.header.cwd
+    if (typeof cwd !== 'string' || !cwd) return null
+    const registry = getWorkspaceRegistry()
+    if (registry) {
+      try {
+        const workspace = await registry.resolveByPath(cwd)
+        if (workspace) return workspace
+      } catch (err) {
+        console.log('dsh-kanban: 解析工作区失败：' + ((err && err.message) || err))
       }
     }
-    return 'default'
+    // 未登记到 WorkspaceRegistry 的会话仍以自身 cwd 作为工作区根目录。
+    return { id: 'cwd:' + cwd, path: cwd, title: cwd }
   }
+  const workspaceOfId = (id) => {
+    const registry = getWorkspaceRegistry()
+    return registry && typeof registry.get === 'function' ? registry.get(id) : undefined
+  }
+  const emptyBoardSummary = { columns: [], labels: [], cards: [] }
 
   const runTool = async (method, args, exec) => {
-    const wsid = await wsidOfExec(exec)
-    const r = await dispatch(wsid, method, args, 'agent')
+    const workspace = await workspaceOfExec(exec)
+    if (!workspace) {
+      return {
+        ok: false,
+        message: 'Cannot determine the current workspace from the tool execution context',
+        board: emptyBoardSummary,
+        warnings: [],
+      }
+    }
+    const session = exec && exec.agent && exec.agent.session
+    const r = await dispatch(workspace, method, args, 'agent', session)
     return {
       ok: !r.error,
       message: r.error || r.message || 'Done',
@@ -715,8 +747,14 @@ export function apply(ctx) {
       const body = raw ? JSON.parse(raw) : {}
       const method = typeof body.method === 'string' ? body.method : 'get'
       const args = body.args || {}
-      const wsid = typeof args.workspaceId === 'string' && args.workspaceId ? args.workspaceId : 'default'
-      const result = await dispatch(wsid, method, args, 'human')
+      const workspaceId = typeof args.workspaceId === 'string' ? args.workspaceId : ''
+      const workspace = workspaceId ? workspaceOfId(workspaceId) : undefined
+      if (!workspace) {
+        res.writeHead(400, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ error: 'Unknown workspace: ' + (workspaceId || '(missing)') }))
+        return
+      }
+      const result = await dispatch(workspace, method, args, 'human')
       res.writeHead(200, { 'content-type': 'application/json' })
       res.end(JSON.stringify(result))
     } catch (err) {
@@ -753,61 +791,63 @@ export function apply(ctx) {
     }
   }
 
-  // ---- 启动校验：全量体检看板文件（只读 + 备份损坏文件，不迁移、不加载内存）----
+  // ---- 启动校验：逐个工作区体检 .dsh-kanban.json（只读 + 备份损坏文件）----
   const startupState = { done: false }
   const maybeStartupCheck = () => {
     if (startupState.done) return
-    if (!getFs()) return
+    const registry = getWorkspaceRegistry()
+    if (!getFs() || !registry || typeof registry.list !== 'function') return
     startupState.done = true
     runStartupCheck()
   }
   const runStartupCheck = async () => {
     const fs = getFs()
-    const wsRoot = root()
-    if (!fs || !wsRoot) return
+    const registry = getWorkspaceRegistry()
+    if (!fs || !registry || typeof registry.list !== 'function') return
     try {
-      const dir = await fs.resolve('.', { cwd: wsRoot })
-      const entries = await fs.listDir(dir)
-      const boardFiles = entries.filter(
-        (e) => typeof e.name === 'string' && /^kanban-board-.+\.json$/.test(e.name),
-      )
-      if (boardFiles.length === 0) {
-        console.log('dsh-kanban: 启动校验完成，未发现看板数据文件')
-        return
-      }
+      const workspaces = registry.list()
+      let found = 0
       let corrupt = 0
       let pendingUpgrade = 0
       let unsupported = 0
       let ok = 0
-      for (const entry of boardFiles) {
-        const wsid = entry.name.slice('kanban-board-'.length, -'.json'.length)
+      for (const workspace of workspaces) {
+        const key = workspaceKey(workspace)
         try {
-          const text = await fs.readText(entry.target)
+          const target = await fs.resolve(BOARD_FILE, { cwd: workspace.path })
+          const text = await fs.readText(target)
+          found++
           const parsed = parseBoardText(text)
           if (parsed.ok) {
             if (parsed.migrated) {
               pendingUpgrade++
-              console.log('dsh-kanban: 启动校验 ' + wsid + '：schemaVersion ' + parsed.fromVersion + '，首次打开时将自动升级')
+              console.log('dsh-kanban: 启动校验 ' + key + '：schemaVersion ' + parsed.fromVersion + '，首次打开时将自动升级')
             } else {
               ok++
             }
           } else if (parsed.kind === 'unsupported') {
             unsupported++
-            console.log('dsh-kanban: 启动校验 ' + wsid + '：文件由更新版本插件写入（schemaVersion ' + parsed.version + '）')
+            console.log('dsh-kanban: 启动校验 ' + key + '：文件由更新版本插件写入（schemaVersion ' + parsed.version + '）')
           } else {
             corrupt++
             const suffix = 'corrupt-' + timestamp()
-            const backupTarget = await fs.resolve(entry.name + '.' + suffix, { cwd: wsRoot })
-            await fs.writeText(backupTarget, text)
-            console.log('dsh-kanban: 启动校验 ' + wsid + '：数据文件损坏（' + parsed.kind + '），已备份为 ' + entry.name + '.' + suffix)
+            const backupTarget = await fs.resolve(BOARD_FILE + '.' + suffix, { cwd: workspace.path })
+            await fs.writeText(backupTarget, text, undefined, undefined, writePolicyFor(workspace))
+            console.log('dsh-kanban: 启动校验 ' + key + '：数据文件损坏（' + parsed.kind + '），已备份为 ' + BOARD_FILE + '.' + suffix)
           }
         } catch (err) {
-          console.log('dsh-kanban: 启动校验 ' + wsid + '：检查失败 ' + ((err && err.message) || err))
+          if (!err || (err.code !== 'ENOENT' && err.message !== 'ENOENT')) {
+            console.log('dsh-kanban: 启动校验 ' + key + '：检查失败 ' + ((err && err.message) || err))
+          }
         }
+      }
+      if (found === 0) {
+        console.log('dsh-kanban: 启动校验完成，未发现看板数据文件')
+        return
       }
       console.log(
         'dsh-kanban: 启动校验完成：共 ' +
-          boardFiles.length +
+          found +
           ' 个看板文件，正常 ' +
           ok +
           '，损坏并已备份 ' +
@@ -914,8 +954,10 @@ export function apply(ctx) {
         },
       },
       async execute(args, exec) {
-        const wsid = await wsidOfExec(exec)
-        const r = await dispatch(wsid, 'getCard', args, 'agent')
+        const workspace = await workspaceOfExec(exec)
+        if (!workspace) return { ok: false, message: 'Cannot determine the current workspace from the tool execution context', warnings: [] }
+        const session = exec && exec.agent && exec.agent.session
+        const r = await dispatch(workspace, 'getCard', args, 'agent', session)
         if (r.error) return { ok: false, message: r.error, warnings: Array.isArray(r.warnings) ? r.warnings : [] }
         return { ok: true, message: 'Card ' + String(args.id || '') + ' details', card: r.card, warnings: Array.isArray(r.warnings) ? r.warnings : [] }
       },
@@ -1122,12 +1164,14 @@ export function apply(ctx) {
         },
       },
       async execute(args, exec) {
-        const wsid = await wsidOfExec(exec)
-        const r = await dispatch(wsid, 'get', args, 'agent')
+        const workspace = await workspaceOfExec(exec)
+        if (!workspace) return { ok: false, message: 'Cannot determine the current workspace from the tool execution context', labels: [], warnings: [] }
+        const session = exec && exec.agent && exec.agent.session
+        const r = await dispatch(workspace, 'get', args, 'agent', session)
         const labels = (r.board && r.board.labels) || []
         return {
           ok: true,
-          message: 'Labels (workspace ' + wsid + ')',
+          message: 'Labels (workspace ' + workspaceKey(workspace) + ')',
           labels,
           warnings: Array.isArray(r.warnings) ? r.warnings : [],
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alpacachen/dsh-kanban",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A kanban board plugin for DeepSeek Harness: a 'Board' tab in conversations plus 14 kanban_* AI tools, per-workspace isolation and disk persistence. Built with React, TypeScript, dnd-kit, shadcn/ui and Tailwind CSS.",
   "type": "module",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
   "scripts": {
     "build": "node build.mjs",
     "check:client-bundle": "node scripts/check-client-bundle.mjs",
+    "check:package": "node scripts/check-package-contents.mjs",
     "check:schema": "node scripts/check-schema.mjs",
     "check:pipeline": "node scripts/check-pipeline.mjs",
-    "test": "pnpm check:schema && pnpm check:pipeline",
+    "test:unit": "vitest run",
+    "test": "pnpm test:unit && pnpm check:schema && pnpm check:pipeline",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -49,16 +51,20 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.0.0",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.5",
     "@types/node": "^22.10.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "esbuild": "^0.28.2",
+    "jsdom": "^26.1.0",
     "postcss": "^8.4.49",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tailwindcss": "^4.0.0",
     "tailwindcss-animate": "^1.0.7",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^3.2.7"
   },
   "license": "MIT",
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,12 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.0.0
         version: 4.3.3
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.6.5
+        version: 14.6.5(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^22.10.0
         version: 22.20.1
@@ -66,6 +72,9 @@ importers:
       esbuild:
         specifier: ^0.28.2
         version: 0.28.2
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
       postcss:
         specifier: ^8.4.49
         version: 8.5.26
@@ -84,12 +93,58 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.7
+        version: 3.2.7(@types/node@22.20.1)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.32.0)
 
 packages:
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -299,6 +354,13 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@radix-ui/number@1.1.3':
     resolution: {integrity: sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==}
@@ -656,6 +718,144 @@ packages:
   '@radix-ui/rect@1.1.3':
     resolution: {integrity: sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==}
 
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    resolution: {integrity: sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    resolution: {integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    resolution: {integrity: sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    resolution: {integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    resolution: {integrity: sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    resolution: {integrity: sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    resolution: {integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    resolution: {integrity: sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    resolution: {integrity: sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==}
+    cpu: [x64]
+    os: [win32]
+
   '@tailwindcss/node@4.3.3':
     resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
 
@@ -748,6 +948,43 @@ packages:
   '@tailwindcss/postcss@4.3.3':
     resolution: {integrity: sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.5':
+    resolution: {integrity: sha512-FhqjldLTpteueBaKflhNFlMT3+PM0O5fiBUivht6b9CZ1eesJyy7+g3Jr7XwJzt/Hip3ZG5hWwK1MX1FuDiE4w==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/node@22.20.1':
     resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
@@ -762,9 +999,69 @@ packages:
   '@types/react@18.3.31':
     resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
 
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
+
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
+
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
+
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
+
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -773,8 +1070,36 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -783,14 +1108,45 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
   enhanced-resolve@5.24.5:
     resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
     engines: {node: '>=10.13.0'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   esbuild@0.28.2:
     resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
@@ -799,12 +1155,43 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -884,30 +1271,71 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lucide-react@0.474.0:
     resolution: {integrity: sha512-CmghgHkh0OJNmxGKWc0qfPJCYHASPMVSyGY8fj3xgk4v84ItqDg64JNKFZn5hC6E0vHi6gxnbCgwhyVB09wQtA==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nwsapi@2.2.24:
+    resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
 
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -943,12 +1371,42 @@ packages:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
+  rollup@4.62.4:
+    resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwind-merge@2.6.1:
     resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
@@ -964,6 +1422,43 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -996,9 +1491,165 @@ packages:
       '@types/react':
         optional: true
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/runtime@7.29.7': {}
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@dnd-kit/accessibility@3.1.1(react@18.3.1)':
     dependencies:
@@ -1138,6 +1789,9 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
 
   '@radix-ui/number@1.1.3': {}
 
@@ -1489,6 +2143,81 @@ snapshots:
 
   '@radix-ui/rect@1.1.3': {}
 
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    optional: true
+
   '@tailwindcss/node@4.3.3':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -1558,6 +2287,42 @@ snapshots:
       postcss: 8.5.26
       tailwindcss: 4.3.3
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@testing-library/user-event@14.6.5(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
   '@types/node@22.20.1':
     dependencies:
       undici-types: 6.21.0
@@ -1573,9 +2338,75 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
+  '@vitest/expect@3.2.7':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.7(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)
+
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.7':
+    dependencies:
+      '@vitest/utils': 3.2.7
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.7':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  agent-base@7.1.4: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  assertion-error@2.0.1: {}
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -1583,16 +2414,42 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.2.3: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decimal.js@10.6.0: {}
+
+  deep-eql@5.0.2: {}
+
+  dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
 
+  dom-accessibility-api@0.5.16: {}
+
   enhanced-resolve@5.24.5:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@6.0.1: {}
+
+  es-module-lexer@1.7.0: {}
 
   esbuild@0.28.2:
     optionalDependencies:
@@ -1623,13 +2480,79 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.2
       '@esbuild/win32-x64': 0.28.2
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fsevents@2.3.3:
+    optional: true
+
   get-nonce@1.0.1: {}
 
   graceful-fs@4.2.11: {}
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  is-potential-custom-element-name@1.0.1: {}
+
   jiti@2.7.0: {}
 
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
+
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.24
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.21.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -1684,17 +2607,37 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
+  lru-cache@10.4.3: {}
+
   lucide-react@0.474.0(react@18.3.1):
     dependencies:
       react: 18.3.1
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  ms@2.1.3: {}
+
   nanoid@3.3.18: {}
 
+  nwsapi@2.2.24: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
   picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
 
   postcss@8.5.26:
     dependencies:
@@ -1702,11 +2645,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  punycode@2.3.1: {}
+
   react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-is@17.0.2: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@18.3.31)(react@18.3.1):
     dependencies:
@@ -1739,11 +2692,63 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  rollup@4.62.4:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.62.4
+      '@rollup/rollup-android-arm64': 4.62.4
+      '@rollup/rollup-darwin-arm64': 4.62.4
+      '@rollup/rollup-darwin-x64': 4.62.4
+      '@rollup/rollup-freebsd-arm64': 4.62.4
+      '@rollup/rollup-freebsd-x64': 4.62.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.4
+      '@rollup/rollup-linux-arm64-gnu': 4.62.4
+      '@rollup/rollup-linux-arm64-musl': 4.62.4
+      '@rollup/rollup-linux-loong64-gnu': 4.62.4
+      '@rollup/rollup-linux-loong64-musl': 4.62.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.4
+      '@rollup/rollup-linux-ppc64-musl': 4.62.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.4
+      '@rollup/rollup-linux-riscv64-musl': 4.62.4
+      '@rollup/rollup-linux-s390x-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-musl': 4.62.4
+      '@rollup/rollup-openbsd-x64': 4.62.4
+      '@rollup/rollup-openharmony-arm64': 4.62.4
+      '@rollup/rollup-win32-arm64-msvc': 4.62.4
+      '@rollup/rollup-win32-ia32-msvc': 4.62.4
+      '@rollup/rollup-win32-x64-gnu': 4.62.4
+      '@rollup/rollup-win32-x64-msvc': 4.62.4
+      fsevents: 2.3.3
+
+  rrweb-cssom@0.8.0: {}
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  symbol-tree@3.2.4: {}
 
   tailwind-merge@2.6.1: {}
 
@@ -1754,6 +2759,35 @@ snapshots:
   tailwindcss@4.3.3: {}
 
   tapable@2.3.3: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tslib@2.8.1: {}
 
@@ -1775,3 +2809,108 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.3.31
+
+  vite-node@3.2.4(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.28.2
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rollup: 4.62.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.20.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+
+  vitest@3.2.7(@types/node@22.20.1)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.32.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)
+      vite-node: 3.2.4(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.20.1
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  ws@8.21.3: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}

--- a/scripts/check-package-contents.mjs
+++ b/scripts/check-package-contents.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { mkdir } from "node:fs/promises"
+import { join } from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const npmCache = join(process.cwd(), ".npm-cache")
+await mkdir(npmCache, { recursive: true })
+const { stdout } = await execFileAsync("npm", ["pack", "--dry-run", "--json"], {
+  encoding: "utf8",
+  env: { ...process.env, npm_config_cache: npmCache },
+})
+const result = JSON.parse(stdout)
+assert.equal(result.length, 1, "npm pack must produce exactly one package manifest")
+
+const files = result[0].files.map(({ path }) => path).sort()
+const expected = [
+  "LICENSE",
+  "README.md",
+  "README.zh.md",
+  "cordis.patch.yml",
+  "image.png",
+  "index.js",
+  "lib/client.js",
+  "package.json",
+].sort()
+
+assert.deepEqual(files, expected, "npm package contents changed; update the allowlist deliberately")
+assert.equal(result[0].entryCount, expected.length, "npm package entry count must match the allowlist")
+assert.ok(result[0].size > 0, "npm package must contain bytes")
+
+console.log(`npm package contents are valid (${files.length} files, ${result[0].size} bytes)`)

--- a/scripts/check-pipeline.mjs
+++ b/scripts/check-pipeline.mjs
@@ -12,6 +12,8 @@
  *   - 版本超前：备份为 .unsupported-vN → 看板以空板可用 → 返回警告
  *   - 后续保存会写入带 schemaVersion 的新格式
  *   - 活动日志：创建/更新/移动/删除均产生对应事件，来源正确
+ *   - 数据写入 <workspace.path>/.dsh-kanban.json，更换 DSH 启动目录后仍可读取
+ *   - 写入使用对应工作区根目录的逐次沙箱策略
  */
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, readdirSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -53,10 +55,30 @@ function bootPlugin(dir) {
         .map((name) => ({ name, target: join(target, name) }))
     },
   }
+  const workspace = { id: 'ws-test', path: dir, title: 'test' }
+  const sandboxPolicy = {
+    defaultMode: 'workspace-write',
+    workspaceRoot: dir,
+    resolve(request = {}) {
+      return { mode: 'workspace-write', workspaceRoot: request.session?.header?.cwd || dir }
+    },
+  }
+  const workspaceRegistry = {
+    get(id) {
+      return id === workspace.id ? workspace : undefined
+    },
+    list() {
+      return [workspace]
+    },
+    async resolveByPath(path) {
+      return path === workspace.path ? workspace : undefined
+    },
+  }
   const ctx = {
     get(key) {
       if (key === 'fs') return fs
-      if (key === 'sandboxPolicy') return { workspaceRoot: dir }
+      if (key === 'sandboxPolicy') return sandboxPolicy
+      if (key === 'workspaceRegistry') return workspaceRegistry
       return undefined
     },
     tools: {
@@ -66,14 +88,79 @@ function bootPlugin(dir) {
     },
   }
   apply(ctx)
+  tools.exec = { agent: { session: { header: { cwd: dir } } } }
   return { tools, dir }
 }
 
-async function runTool(tools, name, args = {}) {
+async function runTool(tools, name, args = {}, exec) {
   const tool = tools.find((t) => t.name === name)
   if (!tool) throw new Error('tool not found: ' + name)
-  return tool.execute(args, {})
+  return tool.execute(args, exec || tools.exec || {})
 }
+
+/** 驱动真实工作区定位：DSH 启动目录与项目根目录彼此独立。 */
+function bootWorkspacePlugin(launchRoot, workspace) {
+  const tools = []
+  const fs = {
+    async resolve(path, opts = {}) {
+      return join(opts.cwd || launchRoot, path)
+    },
+    async readText(target) {
+      if (!existsSync(target)) throw new Error('ENOENT')
+      return readFileSync(target, 'utf8')
+    },
+    async writeText(target, content, expected, signal, policy) {
+      if (!policy || policy.workspaceRoot !== workspace.path) {
+        throw new Error('FS_SANDBOX_DENIED: write policy does not match workspace root')
+      }
+      writeFileSync(target, content, 'utf8')
+      return { version: 1 }
+    },
+    async listDir(target) {
+      return readdirSync(target)
+        .filter((n) => !n.startsWith('.'))
+        .map((name) => ({ name, target: join(target, name) }))
+    },
+  }
+  const sandboxPolicy = {
+    defaultMode: 'workspace-write',
+    workspaceRoot: launchRoot,
+    resolve(request = {}) {
+      return {
+        mode: 'workspace-write',
+        workspaceRoot: request.session?.header?.cwd || launchRoot,
+      }
+    },
+  }
+  const workspaceRegistry = {
+    get(id) {
+      return id === workspace.id ? workspace : undefined
+    },
+    list() {
+      return [workspace]
+    },
+    async resolveByPath(path) {
+      return path === workspace.path ? workspace : undefined
+    },
+  }
+  const ctx = {
+    get(key) {
+      if (key === 'fs') return fs
+      if (key === 'sandboxPolicy') return sandboxPolicy
+      if (key === 'workspaceRegistry') return workspaceRegistry
+      return undefined
+    },
+    tools: {
+      register(tool) {
+        tools.push(tool)
+      },
+    },
+  }
+  apply(ctx)
+  return { tools }
+}
+
+const execAt = (cwd) => ({ agent: { session: { header: { cwd } } } })
 
 const dir = mkdtempSync(join(tmpdir(), 'dsh-kanban-check-'))
 try {
@@ -82,7 +169,7 @@ try {
   {
     const { tools } = bootPlugin(dir)
     writeFileSync(
-      join(dir, 'kanban-board-default.json'),
+      join(dir, '.dsh-kanban.json'),
       JSON.stringify({
         columns: [{ id: 'c1', title: 'Todo' }, { id: 'c2', title: 'Done' }],
         labels: [{ name: 'bug', color: '#F87171' }],
@@ -95,11 +182,11 @@ try {
     check('警告提到自动升级', r.warnings.some((w) => w.includes('upgraded')))
     check('看板数据完整', r.board.cards.length === 1 && r.board.cards[0].title === 'Old card')
 
-    const onDisk = JSON.parse(readFileSync(join(dir, 'kanban-board-default.json'), 'utf8'))
+    const onDisk = JSON.parse(readFileSync(join(dir, '.dsh-kanban.json'), 'utf8'))
     check('写回 schemaVersion 2', onDisk.schemaVersion === 2)
     check('写回保留数据', onDisk.cards.length === 1 && onDisk.columns.length === 2)
-    check('备份 .bak-v0 存在', existsSync(join(dir, 'kanban-board-default.json.bak-v0')))
-    const bak = JSON.parse(readFileSync(join(dir, 'kanban-board-default.json.bak-v0'), 'utf8'))
+    check('备份 .bak-v0 存在', existsSync(join(dir, '.dsh-kanban.json.bak-v0')))
+    const bak = JSON.parse(readFileSync(join(dir, '.dsh-kanban.json.bak-v0'), 'utf8'))
     check('备份为迁移前原样（无版本字段）', bak.schemaVersion === undefined && bak.cards[0].id === 'k1')
 
     // 二次加载：不再迁移、不再警告
@@ -114,13 +201,13 @@ try {
     mkdirSync(dir, { recursive: true })
     const { tools } = bootPlugin(dir)
     writeFileSync(
-      join(dir, 'kanban-board-default.json'),
+      join(dir, '.dsh-kanban.json'),
       JSON.stringify({ schemaVersion: 2, columns: [{ id: 'c1', title: 'Todo' }], labels: [], cards: [], activities: [] }),
     )
     const r = await runTool(tools, 'kanban_get')
     check('工具返回 ok', r.ok === true)
     check('无警告', r.warnings.length === 0)
-    check('无 .bak 备份生成', !existsSync(join(dir, 'kanban-board-default.json.bak-v0')) && !existsSync(join(dir, 'kanban-board-default.json.bak-v1')))
+    check('无 .bak 备份生成', !existsSync(join(dir, '.dsh-kanban.json.bak-v0')) && !existsSync(join(dir, '.dsh-kanban.json.bak-v1')))
   }
 
   // ---- 场景 B2：v1 文件 → 自动升级到 v2 ----
@@ -130,17 +217,17 @@ try {
     mkdirSync(dir, { recursive: true })
     const { tools } = bootPlugin(dir)
     writeFileSync(
-      join(dir, 'kanban-board-default.json'),
+      join(dir, '.dsh-kanban.json'),
       JSON.stringify({ schemaVersion: 1, columns: [{ id: 'c1', title: 'Todo' }], labels: [], cards: [{ id: 'k1', columnId: 'c1', title: 'Old', note: 'n' }] }),
     )
     const r = await runTool(tools, 'kanban_get')
     check('工具返回 ok', r.ok === true, JSON.stringify(r))
     check('返回升级警告', r.warnings.some((w) => w.includes('upgraded')))
-    const onDisk = JSON.parse(readFileSync(join(dir, 'kanban-board-default.json'), 'utf8'))
+    const onDisk = JSON.parse(readFileSync(join(dir, '.dsh-kanban.json'), 'utf8'))
     check('写回 schemaVersion 2', onDisk.schemaVersion === 2)
     check('activities 已初始化', Array.isArray(onDisk.activities) && onDisk.activities.length === 0)
     check('卡片 createdAt/createdBy 为 null', onDisk.cards[0].createdAt === null && onDisk.cards[0].createdBy === null)
-    check('备份 .bak-v1 存在', existsSync(join(dir, 'kanban-board-default.json.bak-v1')))
+    check('备份 .bak-v1 存在', existsSync(join(dir, '.dsh-kanban.json.bak-v1')))
   }
 
   // ---- 场景 C：损坏文件 → 备份 + 空板可用 ----
@@ -149,7 +236,7 @@ try {
     rmSync(dir, { recursive: true, force: true })
     mkdirSync(dir, { recursive: true })
     const { tools } = bootPlugin(dir)
-    writeFileSync(join(dir, 'kanban-board-default.json'), '{"columns": [broken!!', 'utf8')
+    writeFileSync(join(dir, '.dsh-kanban.json'), '{"columns": [broken!!', 'utf8')
     const r = await runTool(tools, 'kanban_get')
     check('工具返回 ok（看板仍可用）', r.ok === true, JSON.stringify(r))
     check('返回损坏警告', r.warnings.some((w) => w.includes('backed up')))
@@ -160,10 +247,9 @@ try {
     check('备份保留原始损坏内容', backups.every((b) => readFileSync(join(dir, b), 'utf8') === '{"columns": [broken!!'))
 
     // 保存会写回新格式，原损坏文件被替换但备份仍在
-    const tool = tools.find((t) => t.name === 'kanban_add_card')
-    const add = await tool.execute({ title: 'New after corrupt' }, {})
+    const add = await runTool(tools, 'kanban_add_card', { title: 'New after corrupt' })
     check('损坏后仍可写卡', add.ok === true)
-    const onDisk = JSON.parse(readFileSync(join(dir, 'kanban-board-default.json'), 'utf8'))
+    const onDisk = JSON.parse(readFileSync(join(dir, '.dsh-kanban.json'), 'utf8'))
     check('保存写出 schemaVersion', onDisk.schemaVersion === 2 && onDisk.cards.length === 1)
     check('新增卡片产生 card_created 事件', Array.isArray(onDisk.activities) && onDisk.activities.length === 1 && onDisk.activities[0].type === 'card_created')
   }
@@ -175,15 +261,15 @@ try {
     mkdirSync(dir, { recursive: true })
     const { tools } = bootPlugin(dir)
     writeFileSync(
-      join(dir, 'kanban-board-default.json'),
+      join(dir, '.dsh-kanban.json'),
       JSON.stringify({ schemaVersion: 99, columns: [{ id: 'c1', title: 'Future' }], labels: [], cards: [] }),
     )
     const r = await runTool(tools, 'kanban_get')
     check('工具返回 ok', r.ok === true)
     check('返回版本超前警告', r.warnings.some((w) => w.includes('newer plugin version')))
     check('看板为空板', r.board.cards.length === 0 && r.board.columns[0] && r.board.columns[0].title !== 'Future')
-    check('生成 .unsupported-v99 备份', existsSync(join(dir, 'kanban-board-default.json.unsupported-v99')))
-    check('原文件未被覆盖', JSON.parse(readFileSync(join(dir, 'kanban-board-default.json'), 'utf8')).schemaVersion === 99)
+    check('生成 .unsupported-v99 备份', existsSync(join(dir, '.dsh-kanban.json.unsupported-v99')))
+    check('原文件未被覆盖', JSON.parse(readFileSync(join(dir, '.dsh-kanban.json'), 'utf8')).schemaVersion === 99)
   }
 
   // ---- 场景 E：启动校验扫描 ----
@@ -191,8 +277,8 @@ try {
   {
     rmSync(dir, { recursive: true, force: true })
     mkdirSync(dir, { recursive: true })
-    writeFileSync(join(dir, 'kanban-board-a.json'), '{"columns": [broken', 'utf8')
-    writeFileSync(join(dir, 'kanban-board-b.json'), JSON.stringify({ columns: [{ id: 'c1', title: 'Todo' }], labels: [], cards: [] }), 'utf8')
+    writeFileSync(join(dir, '.dsh-kanban.json'), '{"columns": [broken', 'utf8')
+    writeFileSync(join(dir, 'kanban-board-old.json'), JSON.stringify({ columns: [], labels: [], cards: [] }), 'utf8')
     writeFileSync(join(dir, 'unrelated.txt'), 'hello', 'utf8')
     bootPlugin(dir) // apply 触发 maybeStartupCheck（异步 fire-and-forget）
 
@@ -205,7 +291,7 @@ try {
       await new Promise((r) => setTimeout(r, 25))
     }
     check('启动校验备份损坏文件', backups.length === 1, JSON.stringify(backups))
-    check('未备份合法文件', !existsSync(join(dir, 'kanban-board-b.json.bak-v0')))
+    check('忽略旧启动目录格式文件', !existsSync(join(dir, 'kanban-board-old.json.bak-v0')))
     check('忽略无关文件', readdirSync(dir).filter((n) => n.includes('unrelated')).length === 1)
   }
 
@@ -218,27 +304,51 @@ try {
 
     const add = await runTool(tools, 'kanban_add_card', { title: 'Task A', label: 'bug', priority: 'high' })
     check('addCard 成功', add.ok === true, JSON.stringify(add))
-    const disk1 = JSON.parse(readFileSync(join(dir, 'kanban-board-default.json'), 'utf8'))
+    const disk1 = JSON.parse(readFileSync(join(dir, '.dsh-kanban.json'), 'utf8'))
     const cardId = disk1.cards[0].id
     check('记录 card_created 且来源为 agent', disk1.activities.length === 1 && disk1.activities[0].type === 'card_created' && disk1.activities[0].source === 'agent')
     check('card_created 带初始标签/优先级', disk1.activities[0].meta && disk1.activities[0].meta.label === 'bug' && disk1.activities[0].meta.priority === 'high')
     check('卡片记录 createdAt/createdBy', disk1.cards[0].createdBy === 'agent' && typeof disk1.cards[0].createdAt === 'string')
 
     await runTool(tools, 'kanban_update_card', { id: cardId, priority: 'low', label: 'Feedback' })
-    const disk2 = JSON.parse(readFileSync(join(dir, 'kanban-board-default.json'), 'utf8'))
+    const disk2 = JSON.parse(readFileSync(join(dir, '.dsh-kanban.json'), 'utf8'))
     const types2 = disk2.activities.map((a) => a.type)
     check('记录 priority 与 label 变化', types2.includes('card_priority_changed') && types2.includes('card_label_changed'))
 
-    const board2 = JSON.parse(readFileSync(join(dir, 'kanban-board-default.json'), 'utf8'))
+    const board2 = JSON.parse(readFileSync(join(dir, '.dsh-kanban.json'), 'utf8'))
     const inProgress = board2.columns.find((c) => c.title === 'In Progress')
     await runTool(tools, 'kanban_move_card', { id: cardId, columnId: inProgress.id })
-    const disk3 = JSON.parse(readFileSync(join(dir, 'kanban-board-default.json'), 'utf8'))
+    const disk3 = JSON.parse(readFileSync(join(dir, '.dsh-kanban.json'), 'utf8'))
     const moved = disk3.activities.find((a) => a.type === 'card_moved')
     check('记录 card_moved 跨列', !!moved && moved.from === 'Todo' && moved.to === 'In Progress')
 
     await runTool(tools, 'kanban_delete_card', { id: cardId })
-    const disk4 = JSON.parse(readFileSync(join(dir, 'kanban-board-default.json'), 'utf8'))
+    const disk4 = JSON.parse(readFileSync(join(dir, '.dsh-kanban.json'), 'utf8'))
     check('记录 card_deleted', disk4.activities.some((a) => a.type === 'card_deleted' && a.cardId === cardId))
+  }
+
+  // ---- 场景 G：看板跟随工作区，而不是 DSH 启动目录 ----
+  console.log('\n[G] 更换 DSH 启动目录后仍读取同一工作区看板')
+  {
+    rmSync(dir, { recursive: true, force: true })
+    mkdirSync(dir, { recursive: true })
+    const launchA = join(dir, 'launch-a')
+    const launchB = join(dir, 'launch-b')
+    const workspacePath = join(dir, 'project')
+    mkdirSync(launchA)
+    mkdirSync(launchB)
+    mkdirSync(workspacePath)
+    const workspace = { id: 'ws-project', path: workspacePath, title: 'project' }
+
+    const first = bootWorkspacePlugin(launchA, workspace)
+    const added = await runTool(first.tools, 'kanban_add_card', { title: 'Survives restart' }, execAt(workspacePath))
+    check('首次写卡成功', added.ok === true, JSON.stringify(added))
+    check('数据写入工作区根目录', existsSync(join(workspacePath, '.dsh-kanban.json')))
+    check('启动目录不产生看板文件', readdirSync(launchA).every((name) => !name.includes('kanban')))
+
+    const second = bootWorkspacePlugin(launchB, workspace)
+    const loaded = await runTool(second.tools, 'kanban_get', {}, execAt(workspacePath))
+    check('更换启动目录后任务仍存在', loaded.board.cards.some((card) => card.title === 'Survives restart'))
   }
 } finally {
   rmSync(dir, { recursive: true, force: true })

--- a/src/client/components/ColumnDialog.tsx
+++ b/src/client/components/ColumnDialog.tsx
@@ -58,7 +58,14 @@ function SortableRow({ column, value, onValueChange, onCommit, onDelete, canDele
           if (e.key === "Enter") (e.target as HTMLInputElement).blur()
         }}
       />
-      <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0 text-destructive" disabled={!canDelete} onClick={onDelete}>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8 shrink-0 text-destructive"
+        aria-label={t("delete")}
+        disabled={!canDelete}
+        onClick={onDelete}
+      >
         <Trash2 className="h-4 w-4" />
       </Button>
     </div>

--- a/test/host.test.mjs
+++ b/test/host.test.mjs
@@ -1,0 +1,135 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it } from "vitest"
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { apply, parseBoardText, SCHEMA_VERSION } from "../index.js"
+
+const workspaces = []
+
+afterEach(() => {
+  for (const dir of workspaces.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+function boot(dir = mkdtempSync(join(tmpdir(), "dsh-kanban-test-"))) {
+  workspaces.push(dir)
+  const workspace = { id: "ws-test", path: dir, title: "Test" }
+  const registered = []
+  const fs = {
+    async resolve(path, options = {}) {
+      return join(options.cwd || dir, path)
+    },
+    async readText(target) {
+      if (!existsSync(target)) {
+        const error = new Error("ENOENT")
+        error.code = "ENOENT"
+        throw error
+      }
+      return readFileSync(target, "utf8")
+    },
+    async writeText(target, content) {
+      writeFileSync(target, content, "utf8")
+      return { version: 1 }
+    },
+  }
+  const ctx = {
+    get(name) {
+      if (name === "fs") return fs
+      if (name === "sandboxPolicy") return { defaultMode: "workspace-write", resolve: () => ({ mode: "workspace-write" }) }
+      if (name === "workspaceRegistry") return {
+        get: (id) => id === workspace.id ? workspace : undefined,
+        list: () => [workspace],
+        resolveByPath: async (path) => path === workspace.path ? workspace : undefined,
+      }
+      return undefined
+    },
+    tools: {
+      register(tool) { registered.push(tool) },
+    },
+  }
+  apply(ctx)
+  const exec = { agent: { session: { header: { cwd: dir } } } }
+  return { dir, workspace, registered, exec }
+}
+
+const tool = (registered, name) => {
+  const found = registered.find((candidate) => candidate.name === name)
+  expect(found, `missing registered tool ${name}`).toBeTruthy()
+  return found
+}
+
+describe("host board seam", () => {
+  it("migrates legacy data through the public parser contract", () => {
+    const parsed = parseBoardText(JSON.stringify({
+      columns: [{ id: "c1", title: "Todo" }],
+      cards: [{ id: "k1", columnId: "c1", title: "Migrate me" }],
+    }))
+
+    expect(parsed.ok).toBe(true)
+    expect(parsed.data.schemaVersion).toBe(SCHEMA_VERSION)
+    expect(parsed.data.activities).toEqual([])
+    expect(parsed.data.cards[0]).toMatchObject({ note: "", label: null, priority: null, createdAt: null, createdBy: null })
+  })
+
+  it("registers every model tool with a usable schema", () => {
+    const { registered } = boot()
+    const names = registered.map(({ name }) => name)
+
+    expect(names).toHaveLength(14)
+    expect(new Set(names).size).toBe(14)
+    for (const registeredTool of registered) {
+      expect(registeredTool.name).toMatch(/^kanban_/)
+      expect(registeredTool.parameters).toMatchObject({ type: "object" })
+      expect(typeof registeredTool.execute).toBe("function")
+      expect(registeredTool.output.schema).toMatchObject({ type: "object", required: ["ok", "message"] })
+    }
+
+    expect(tool(registered, "kanban_add_card").parameters.required).toEqual(["title"])
+    expect(tool(registered, "kanban_update_card").parameters.required).toEqual(["id"])
+    expect(tool(registered, "kanban_move_card").parameters.properties.toIndex).toMatchObject({ type: "integer" })
+    expect(tool(registered, "kanban_add_card").parameters.properties.priority.enum).toEqual(["high", "medium", "low"])
+  })
+
+  it("executes CRUD through registered tools and persists activity history", async () => {
+    const { dir, registered, exec } = boot()
+    const add = await tool(registered, "kanban_add_card").execute({ title: "Ship tests", note: "Keep the gate green", priority: "high" }, exec)
+    expect(add).toMatchObject({ ok: true, message: expect.stringContaining("Card added") })
+    const card = add.board.cards[0]
+    const target = add.board.columns.find((column) => column.title === "Done")
+
+    const update = await tool(registered, "kanban_update_card").execute({ id: card.id, priority: "low" }, exec)
+    expect(update).toMatchObject({ ok: true, message: "Card updated" })
+    const move = await tool(registered, "kanban_move_card").execute({ id: card.id, columnId: target.id }, exec)
+    expect(move).toMatchObject({ ok: true, message: 'Moved to "Done"' })
+    const deleted = await tool(registered, "kanban_delete_card").execute({ id: card.id }, exec)
+    expect(deleted).toMatchObject({ ok: true, message: "Card deleted" })
+
+    const persisted = JSON.parse(readFileSync(join(dir, ".dsh-kanban.json"), "utf8"))
+    expect(persisted.schemaVersion).toBe(SCHEMA_VERSION)
+    expect(persisted.cards).toEqual([])
+    expect(persisted.activities.map(({ type }) => type)).toEqual([
+      "card_created",
+      "card_priority_changed",
+      "card_moved",
+      "card_deleted",
+    ])
+  })
+
+  it("backs up and writes back a migrated workspace file on first tool access", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "dsh-kanban-migration-"))
+    workspaces.push(dir)
+    writeFileSync(join(dir, ".dsh-kanban.json"), JSON.stringify({
+      schemaVersion: 1,
+      columns: [{ id: "c1", title: "Todo" }],
+      labels: [],
+      cards: [{ id: "k1", columnId: "c1", title: "Old" }],
+    }))
+    const { registered, exec } = boot(dir)
+    const result = await tool(registered, "kanban_get").execute({}, exec)
+
+    expect(result).toMatchObject({ ok: true, board: { cards: [{ id: "k1", title: "Old" }] } })
+    expect(result.warnings.some((warning) => warning.includes("automatically upgraded"))).toBe(true)
+    expect(existsSync(join(dir, ".dsh-kanban.json.bak-v1"))).toBe(true)
+    expect(JSON.parse(readFileSync(join(dir, ".dsh-kanban.json"), "utf8"))).toMatchObject({ schemaVersion: SCHEMA_VERSION, activities: [] })
+  })
+})

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,27 @@
+import { cleanup } from "@testing-library/react"
+import { afterEach } from "vitest"
+
+afterEach(() => {
+  cleanup()
+})
+
+if (!globalThis.ResizeObserver) {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as typeof ResizeObserver
+}
+
+if (typeof window !== "undefined" && !window.matchMedia) {
+  window.matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener() {},
+    removeListener() {},
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() { return false },
+  }) as MediaQueryList
+}

--- a/test/ui.test.tsx
+++ b/test/ui.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+import { CardDialog, type CardFormValues } from "../src/client/components/CardDialog"
+import { ColumnDialog } from "../src/client/components/ColumnDialog"
+
+const labels = [{ name: "bug", color: "#f87171" }]
+const activities = []
+
+function cardValues(overrides: Partial<CardFormValues> = {}): CardFormValues {
+  return { id: "", title: "", note: "", label: "", priority: "", ...overrides }
+}
+
+describe("CardDialog user flows", () => {
+  it("submits the edited fields and closes after save", async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn()
+    const onOpenChange = vi.fn()
+    render(
+      <CardDialog
+        open
+        card={null}
+        labels={labels}
+        activities={activities}
+        onOpenChange={onOpenChange}
+        onSave={onSave}
+        onChatWithAgent={vi.fn()}
+      />,
+    )
+
+    await user.type(screen.getByLabelText("标题"), "Release gate")
+    await user.type(screen.getByLabelText("备注"), "Build, typecheck, pack")
+    await user.click(screen.getByRole("button", { name: "保存" }))
+
+    expect(onSave).toHaveBeenCalledWith(cardValues({ title: "Release gate", note: "Build, typecheck, pack" }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it("sends the current-card action to the selected chat target", async () => {
+    const user = userEvent.setup()
+    const onChatWithAgent = vi.fn()
+    const onOpenChange = vi.fn()
+    render(
+      <CardDialog
+        open
+        card={null}
+        labels={labels}
+        activities={activities}
+        onOpenChange={onOpenChange}
+        onSave={vi.fn()}
+        onChatWithAgent={onChatWithAgent}
+      />,
+    )
+
+    await user.type(screen.getByLabelText("备注"), "Investigate the failing build")
+    await user.click(screen.getByRole("button", { name: /与 agent 聊一聊/ }))
+    await user.click(screen.getByRole("menuitem", { name: "当前对话" }))
+
+    expect(onChatWithAgent).toHaveBeenCalledWith(
+      cardValues({ note: "Investigate the failing build" }),
+      "current",
+    )
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it("deletes an existing card and closes the dialog", async () => {
+    const user = userEvent.setup()
+    const card = { id: "k1", columnId: "c1", title: "Remove me", note: "", label: null, priority: null, createdAt: null, createdBy: null }
+    const onDelete = vi.fn()
+    const onOpenChange = vi.fn()
+    render(
+      <CardDialog
+        open
+        card={card}
+        labels={labels}
+        activities={activities}
+        onOpenChange={onOpenChange}
+        onSave={vi.fn()}
+        onDelete={onDelete}
+        onChatWithAgent={vi.fn()}
+      />,
+    )
+
+    await user.click(screen.getByRole("button", { name: "删除" }))
+
+    expect(onDelete).toHaveBeenCalledWith(card)
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})
+
+describe("ColumnDialog user flows", () => {
+  const columns = [
+    { id: "c1", title: "Todo" },
+    { id: "c2", title: "Done" },
+  ]
+
+  it("commits a rename, adds a list, and deletes a list", async () => {
+    const user = userEvent.setup()
+    const onRename = vi.fn()
+    const onAdd = vi.fn()
+    const onDelete = vi.fn()
+    render(
+      <ColumnDialog
+        open
+        columns={columns}
+        onOpenChange={vi.fn()}
+        onReorder={vi.fn()}
+        onRename={onRename}
+        onDelete={onDelete}
+        onAdd={onAdd}
+      />,
+    )
+
+    const [firstColumn] = screen.getAllByRole("textbox")
+    await user.clear(firstColumn)
+    await user.type(firstColumn, "Backlog")
+    fireEvent.blur(firstColumn)
+    await user.type(screen.getByPlaceholderText("新列表名称"), "Blocked")
+    await user.click(screen.getByRole("button", { name: /添加/ }))
+    await user.click(screen.getAllByRole("button", { name: "删除" })[0])
+
+    expect(onRename).toHaveBeenCalledWith("c1", "Backlog")
+    expect(onAdd).toHaveBeenCalledWith("Blocked")
+    expect(onDelete).toHaveBeenCalledWith("c1")
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { defineConfig } from "vitest/config"
+
+const root = fileURLToPath(new URL(".", import.meta.url))
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": resolve(root, "src/client"),
+    },
+  },
+  test: {
+    include: ["test/**/*.{test,spec}.{mjs,ts,tsx}"],
+    environment: "jsdom",
+    setupFiles: ["./test/setup.ts"],
+  },
+})


### PR DESCRIPTION
## Summary
- add Vitest host tests for schema migration, tool registration/schema, CRUD, activity history, and persistence
- add React/jsdom integration tests for CardDialog and ColumnDialog interactions
- add npm package content allowlist validation
- run unit/integration tests, build, typecheck, client bundle validation, and package checks in CI and release workflows

## Validation
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm check:client-bundle`
- `pnpm check:package`

Closes k18